### PR TITLE
Enable opening blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: 💬 PyDelhi WhatsApp
     url: https://chat.whatsapp.com/IUA2o1Xu8w8LmaZ8bw0nbb


### PR DESCRIPTION
I'd like to open a few issues related to talk proposals and around guidelines for submissions, but not talk proposals themselves – I've created a ["meta" label ](https://github.com/pydelhi/talks/issues?q=sort:updated-desc+is:open+label:meta)for this and would like them to be blank