### PR TITLE
Fix links in talk proposal template

### DIFF
--- a/.github/ISSUE_TEMPLATE/talk-proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/talk-proposal.yaml
@@ -7,7 +7,7 @@ body:
       value: |
         Thanks for taking the time to share your learnings with the PyDelhi community! 👋
 
-        We would highly recommend you go through our [guidelines on submitting a proposal and presenting](../guidelines/speaking.md) and [accessibility guidelines](../guidelines/accessibility.md), **especially if it is your first time**.
+        We would highly recommend you go through our [guidelines on submitting a proposal and presenting](https://github.com/pydelhi/talks/blob/main/guidelines/speaking.md) and [accessibility guidelines](https://github.com/pydelhi/talks/blob/main/guidelines/accessibility.md), **especially if it is your first time**.
 
         Please note that all talks are licensed under a [Creative Commons Attribution-Non Commercial-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0/), unless you state otherwise and request the use of a different license of your choosing, either in your proposal below or in the materials you intend to share.
 


### PR DESCRIPTION
### Updated links in talk proposal guidelines to point to the correct GitHub repository.

<img width="890" height="495" alt="issue_solved" src="https://github.com/user-attachments/assets/9d0d65b8-a483-419b-b4ef-36f3740501b2" />