### PR TITLE
Fix broken guidelines links in talk proposal template

### DIFF
--- a/.github/ISSUE_TEMPLATE/talk-proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/talk-proposal.yaml
@@ -7,7 +7,7 @@ body:
       value: |
         Thanks for taking the time to share your learnings with the PyDelhi community! 👋
 
-        We would highly recommend you go through our [guidelines on submitting a proposal and presenting](../guidelines/speaking.md) and [accessibility guidelines](../guidelines/accessibility.md), **especially if it is your first time**.
+        We would highly recommend you go through our [guidelines on submitting a proposal and presenting](https://github.com/pydelhi/talks/blob/main/guidelines/speaking.md) and [accessibility guidelines](https://github.com/pydelhi/talks/blob/main/guidelines/accessibility.md), **especially if it is your first time**.
 
         Please note that all talks are licensed under a [Creative Commons Attribution-Non Commercial-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0/), unless you state otherwise and request the use of a different license of your choosing, either in your proposal below or in the materials you intend to share.
 


### PR DESCRIPTION
Fixes the broken links in the talk proposal template.

Updated the guidelines URLs to point to the correct files:

* speaking.md
* accessibility.md

Created this PR from a separate branch as suggested 🙂

Let me know if any changes are needed!